### PR TITLE
Add search and install tools to MCP Runner

### DIFF
--- a/apps/mcp-dockmaster-cli/Cargo.lock
+++ b/apps/mcp-dockmaster-cli/Cargo.lock
@@ -77,6 +77,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +395,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1212,6 +1244,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -1241,6 +1274,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",

--- a/apps/mcp-dockmaster/src-tauri/Cargo.lock
+++ b/apps/mcp-dockmaster/src-tauri/Cargo.lock
@@ -137,6 +137,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3434,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",

--- a/apps/mcp-runner/@types/lunr/lunr.d.ts
+++ b/apps/mcp-runner/@types/lunr/lunr.d.ts
@@ -1,0 +1,1 @@
+declare module 'lunr';

--- a/apps/mcp-runner/package.json
+++ b/apps/mcp-runner/package.json
@@ -18,11 +18,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.6.1",
+    "lunr": "^2.3.9",
     "node-fetch": "^3.3.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@types/node": "22.13.9",
+    "@types/node": "^22.13.9",
     "@types/node-fetch": "3.0.2",
     "typescript": "5.8.2"
   }

--- a/apps/mcp-runner/src/@types/lunr/lunr.d.ts
+++ b/apps/mcp-runner/src/@types/lunr/lunr.d.ts
@@ -1,0 +1,1 @@
+declare module 'lunr';

--- a/apps/mcp-runner/src/logger.ts
+++ b/apps/mcp-runner/src/logger.ts
@@ -1,0 +1,8 @@
+// Enable debug logging
+const DEBUG = true;
+
+export function debugLog(...args: any[]) {
+  if (DEBUG) {
+    console.error(`[DEBUG ${new Date().toISOString()}]`, ...args);
+  }
+}

--- a/apps/mcp-runner/src/mcpInstall.ts
+++ b/apps/mcp-runner/src/mcpInstall.ts
@@ -1,0 +1,58 @@
+import lunr from "lunr";
+import { proxyRequest } from "./proxyRequest.js";
+import { RegistryTool, Tool, Tools } from "./types.js";
+
+export class MCPInstall {
+  // public static registry: Record<string, Tool> = {};
+  public static name = 'install_mcp_servers_and_tools';
+  public static isInitialized = false;
+
+  public static async install(name: string) {
+    if (!MCPInstall.isInitialized) {
+      throw new Error("MCPInstall is not initialized");
+    }
+    const result = await proxyRequest('registry/install', {
+      tool: name
+    });
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result),
+      }]
+    };
+  }
+  
+  private static setInitialized() {
+    MCPInstall.isInitialized = true;
+  }
+
+  public static async init() {
+    // const result = await proxyRequest<{ tools: RegistryTool[] }>('registry/list', {});
+    // result.tools.forEach((tool: any) => {
+    //   MCPInstall.registry[tool.name] = tool;
+    // });
+    MCPInstall.setInitialized();
+  } 
+
+  static tool: Tool = {
+    "fullDescription": "Installs MCP Servers & Tools available to be installed.",
+    "description": "Installs MCP Servers & Tools available to be installed.",
+      "inputSchema": {
+        "description": "Name of the MCP Server or Tool to install.",
+        "properties": {
+          "name": {
+            "description": "Name of the MCP Server or Tool to install.",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "Install MCP Server",
+        "type": "object"
+      },
+      "name": MCPInstall.name,
+      "server_id": MCPInstall.name
+    };
+}

--- a/apps/mcp-runner/src/mcpSearch.ts
+++ b/apps/mcp-runner/src/mcpSearch.ts
@@ -1,0 +1,91 @@
+import lunr from "lunr";
+import { proxyRequest } from "./proxyRequest.js";
+import { RegistryTool, Tool, Tools } from "./types.js";
+
+export class MCPSearch {
+  public static registry: Record<string, Tool> = {};
+  public static name = 'search_mcp_servers_and_tools';
+  public static isInitialized = false;
+  private static idx: {
+    search: (query: string) => any[];
+  };
+
+  public static search(query: string): {
+    content: {
+      type: 'text';
+      text: string;
+    }[];
+  } {
+    if (!MCPSearch.isInitialized) {
+      throw new Error("MCPSearch is not initialized");
+    }
+    const results: {
+      ref: string;
+      score: number;
+      matchData: {
+        metadata: Record<string, any>;
+      };
+    }[] = MCPSearch.idx.search(query);
+   
+    const tools = results
+      .slice(0, 10)
+      .map((result) => MCPSearch.registry[result.ref])
+      .map(tool => ({
+        name: tool.name, fullDescription: tool.fullDescription, id: tool.name
+      }));
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(tools),
+      }]
+    };
+  }
+  
+  private static setInitialized() {
+    MCPSearch.isInitialized = true;
+    // console.log("MCPSearch initialized");
+    // console.log('Example Search:', "sql database server");
+    // console.log(MCPSearch.search("sql database server"));
+  }
+
+  public static async init() {
+    // const result = await proxyRequest<Tools>('tools/list', {});
+    const result = await proxyRequest<{ tools: RegistryTool[] }>('registry/list', {});
+    // console.log('result registry/list', result);
+    MCPSearch.idx = lunr(function (self: any) {
+      self.ref('name');
+      self.field('name');
+      self.field('fullDescription');
+      result.tools.forEach((tool: any) => {
+        // console.log('[Added Search]', tool.name, tool.description.substring(0, 40) + '...');
+        MCPSearch.registry[tool.name] = tool;
+        self.add(tool)
+      });
+    });
+    MCPSearch.setInitialized();
+  } 
+
+  static tool: Tool = {
+    "fullDescription": "Searches for MCP Servers & Tools available to be installed.",
+    "description": "Searches for MCP Servers & Tools available to be installed.",
+      "inputSchema": {
+        "description": "Query to search for MCP Servers & Tools available to be installed.",
+        "properties": {
+          "query": {
+            "default": "test",
+            "description": "Query to search for MCP Servers & Tools available to be installed.",
+            "title": "Query",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "Search MCP Servers & Tools",
+        "type": "object"
+      },
+      "name": MCPSearch.name,
+      "server_id": MCPSearch.name
+    };
+}

--- a/apps/mcp-runner/src/proxyRequest.ts
+++ b/apps/mcp-runner/src/proxyRequest.ts
@@ -1,0 +1,57 @@
+import { debugLog } from "./logger.js";
+// Target server URL
+
+const TARGET_SERVER_URL = 'http://localhost:3000/mcp-proxy';
+console.error(`Target server: ${TARGET_SERVER_URL}`);
+
+/**
+ * Generic proxy function to forward requests to the target server
+ * @param method The JSON-RPC method to call
+ * @param params The parameters to pass to the method
+ * @returns The response from the target server
+ */
+export async function proxyRequest<T>(method: string, params: any): Promise<T> {
+    debugLog(`proxyRequest called with method: ${method}`);
+    try {
+      console.error(`Proxying request: ${method} to ${TARGET_SERVER_URL}`);
+      console.error(`Request params: ${JSON.stringify(params)}`);
+      
+      // The server only accepts POST requests with JSON-RPC format
+      const requestBody = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params: params || {},
+      });
+      
+      console.error(`Request body: ${requestBody}`);
+      
+      const response = await fetch(TARGET_SERVER_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: requestBody,
+      });
+  
+      if (!response.ok) {
+        const responseText = await response.text();
+        console.error(`HTTP error! status: ${response.status}, response: ${responseText}`);
+        throw new Error(`HTTP error! status: ${response.status}, response: ${responseText}`);
+      }
+  
+      const data = await response.json() as { result: any; error?: { message: string } };
+      
+      if (data.error) {
+        console.error(`Server error: ${JSON.stringify(data.error)}`);
+        throw new Error(`Server error: ${JSON.stringify(data.error)}`);
+      }
+  
+      console.error(`Received response for: ${method}`);
+      console.error(`Response data: ${JSON.stringify(data.result).substring(0, 100)}...`);
+      return data.result;
+    } catch (error) {
+      console.error(`Error proxying request: ${error}`);
+      throw error;
+    }
+  }

--- a/apps/mcp-runner/src/types.ts
+++ b/apps/mcp-runner/src/types.ts
@@ -1,0 +1,81 @@
+export interface Tools {
+    tools: Tool[];
+}
+
+export interface Tool {
+    description: string;
+    fullDescription: string;
+    inputSchema: InputSchema;
+    name:        string;
+    server_id:   string;
+}
+
+export interface InputSchema {
+    description: string;
+    properties:  Properties;
+    required:    string[];
+    title:       string;
+    type:        string;
+}
+
+export interface Properties {
+    [key: string]: {
+        default?: any;
+        description: string;
+        exclusiveMaximum?: number;
+        exclusiveMinimum?: number;
+        minimum?: number;
+        maximum?: number;
+        title: string;
+        type: string;
+    }
+}
+
+
+export interface RegistryTool {
+    id:              string;
+    name:            string;
+    description:     string;
+    fullDescription: string;
+    publisher:       Publisher;
+    isOfficial:      boolean;
+    sourceUrl:       string;
+    distribution:    Distribution;
+    license:         string;
+    runtime:         string;
+    config:          Config;
+}
+
+export interface Config {
+    command: string;
+    args:    string[];
+    env:     Env;
+}
+
+export interface Env {
+    HELIUS_API_KEY?:      HeliusAPIKey;
+    REPLICATE_API_TOKEN?: ReplicateAPIToken;
+    VIRUSTOTAL_API_KEY?:  ReplicateAPIToken;
+}
+
+export interface HeliusAPIKey {
+    required:    boolean;
+    description: string;
+}
+
+export interface ReplicateAPIToken {
+    description: string;
+    type:        string;
+    required:    boolean;
+}
+
+export interface Distribution {
+    type:    string;
+    package: string;
+}
+
+export interface Publisher {
+    id:   string;
+    name: string;
+    url:  string;
+}

--- a/libs/mcp-core/Cargo.lock
+++ b/libs/mcp-core/Cargo.lock
@@ -77,6 +77,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "directories"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +355,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1194,6 +1226,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -1223,6 +1256,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",

--- a/libs/mcp-core/Cargo.toml
+++ b/libs/mcp-core/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["MCP Team"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.0", features = ["full"] }
-reqwest = { version = "0.12.12", features = ["json"] }
+reqwest = { version = "0.12.12", features = ["json", "gzip"] }
 axum = { version = "0.8.1", features = ["macros"] }
 tower = "0.4"
 tower-http = { version = "0.6.2", features = ["cors"] }

--- a/libs/mcp-core/src/models/types.rs
+++ b/libs/mcp-core/src/models/types.rs
@@ -96,7 +96,7 @@ pub struct Tool {
 //     pub server_tools: HashMap<ToolId, Vec<Value>>,
 
 /// MCP tool registration request
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ToolRegistrationRequest {
     pub tool_name: String,
     pub description: String,
@@ -108,7 +108,7 @@ pub struct ToolRegistrationRequest {
 }
 
 /// MCP tool registration response
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct ToolRegistrationResponse {
     pub success: bool,
     pub message: String,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,6 +1771,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.6.1",
+        "lunr": "^2.3.9",
         "node-fetch": "^3.3.2",
         "zod": "^3.24.2"
       },
@@ -1778,7 +1779,7 @@
         "mcp-proxy-server": "build/index.js"
       },
       "devDependencies": {
-        "@types/node": "22.13.9",
+        "@types/node": "^22.13.9",
         "@types/node-fetch": "3.0.2",
         "typescript": "5.8.2"
       }
@@ -3698,6 +3699,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",


### PR DESCRIPTION
Implement two new internal tools for the MCP Runner:
- MCPSearch: Enables searching available MCP servers and tools using Lunr.js
- MCPInstall: Allows installing MCP servers and tools from a remote registry

Changes include:
- Added Lunr.js dependency
- Created new TypeScript modules for search and install functionality
- Updated proxy request handling to support new tools
- Added type definitions and utility modules