### PR TITLE
fix: local dev task

### DIFF
--- a/apps/mcp-dockmaster/project.json
+++ b/apps/mcp-dockmaster/project.json
@@ -42,26 +42,10 @@
       }
     },
     "serve": {
-      "executor": "@nx/vite:dev-server",
-      "defaultConfiguration": "development",
-      "options": {
-        "buildTarget": "mcp-dockmaster:build"
-      },
-      "configurations": {
-        "development": {
-          "buildTarget": "mcp-dockmaster:build:development",
-          "hmr": true
-        },
-        "production": {
-          "buildTarget": "mcp-dockmaster:build:production",
-          "hmr": false
-        }
-      }
-    },
-    "serve-tauri": {
+      "dependsOn": ["copy-proxy-server-sidecar"],
       "executor": "nx:run-commands",
       "options": {
-        "command": "npx tauri dev",
+        "command": "npx tauri dev --config=\"src-tauri/tauri.conf.local.json\"",
         "cwd": "apps/mcp-dockmaster"
       }
     },

--- a/apps/mcp-dockmaster/src-tauri/tauri.conf.local.json
+++ b/apps/mcp-dockmaster/src-tauri/tauri.conf.local.json
@@ -1,5 +1,5 @@
 {
-  "productName": "MCP Dockmaster",
+  "productName": "MCP Dockmaster Local",
   "identifier": "com.mcp-dockmaster.desktop.local",
   "bundle": {
     "createUpdaterArtifacts": false


### PR DESCRIPTION
- now the app uses the right tauri conf when running in local. This is important because some CLaude/Cursor validations depends on this for local work